### PR TITLE
Now triggering a 'Termly.consentSaveDone' event when the template is done

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -48,6 +48,7 @@ const Object = require('Object');
 
 const callInWindow = require('callInWindow');
 const copyFromDataLayer = require('copyFromDataLayer');
+const createQueue = require('createQueue');
 const localStorage = require('localStorage');
 const logToConsole = require('logToConsole');
 const setDefaultConsentState = require('setDefaultConsentState');
@@ -56,6 +57,7 @@ const updateConsentState = require('updateConsentState');
 const DEFAULT_WAIT_FOR_UPDATE = 500;
 const IS_DEFAULT_STATE = 'is_default_state';
 const LOCAL_STORAGE_KEY = 'termly_gtm_template_default_consents';
+const UPDATE_COMPLETE_EVENT_NAME = 'Termly.consentSaveDone';
 
 const GTM_TO_TERMLY = {
   ad_storage: 'advertising',
@@ -83,6 +85,8 @@ const EVENT_HANDLERS = {
   const result = handler(event);
 
   if ( result ) {
+    triggerEvent(UPDATE_COMPLETE_EVENT_NAME);
+
     data.gtmOnSuccess();
   } else {
     data.gtmOnFailure();
@@ -190,6 +194,14 @@ function addWaitForUpdate(state) {
     });
 
   return newState;
+}
+
+function triggerEvent(eventName) {
+  const dataLayerPush = createQueue('dataLayer');
+
+  dataLayerPush({
+    event: eventName,
+  });
 }
 
 
@@ -565,6 +577,45 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 8,
                     "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "dataLayer"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": false
                   }
                 ]
               }


### PR DESCRIPTION
Work for TER-10750.

This event will fire twice...once for initialization, and another time after handling `userPrefUpdate`:

<img width="253" alt="Screen Shot 2022-04-06 at 11 32 59 AM" src="https://user-images.githubusercontent.com/71285654/162044471-506b033e-b9f2-461c-889a-98a8e9875049.png">

